### PR TITLE
Some dark window tweaks for you to consider

### DIFF
--- a/extensions/console/internal.m
+++ b/extensions/console/internal.m
@@ -25,6 +25,7 @@
 @property IBOutlet NSTextView *outputView;
 @property (weak) IBOutlet NSTextField *inputField;
 
+- (void) reflectDefaults ;
 @end
 
 static int refTable = LUA_NOREF;
@@ -41,11 +42,12 @@ static int refTable = LUA_NOREF;
 static int consoleDarkMode(lua_State* L) {
     LuaSkin *skin = [LuaSkin shared];
     [skin checkArgs:LS_TBOOLEAN|LS_TOPTIONAL, LS_TBREAK];
-    
+
     if (lua_isboolean(L, -1)) {
         ConsoleDarkModeSetEnabled(lua_toboolean(L, -1));
+        [[MJConsoleWindowController singleton] reflectDefaults] ;
     }
-    
+
     lua_pushboolean(L, ConsoleDarkModeEnabled()) ;
     return 1;
 }
@@ -569,9 +571,9 @@ static int console_titleVisibility(lua_State *L) {
 
 static const luaL_Reg extrasLib[] = {
 //     {"asHSDrawing", console_asDrawing},
-    
+
     {"darkMode", consoleDarkMode},
-    
+
     {"hswindow", console_asWindow},
 
     {"windowBackgroundColor", console_backgroundColor},

--- a/extensions/doc/hsdocs/init.lua
+++ b/extensions/doc/hsdocs/init.lua
@@ -282,6 +282,7 @@ local makeToolbar = function(browser)
               local current = module.browserDarkMode()
               if type(current) == "nil" then current = (host.interfaceStyle() == "Dark") end
               w:evaluateJavaScript("setInvertLevel(" .. (current and "100" or "0") .. ")")
+              module._browser:darkMode(current)
           elseif i == "track" then
               local track = module.trackBrowserFrame()
               if track then

--- a/extensions/doc/hsdocs/search.lp
+++ b/extensions/doc/hsdocs/search.lp
@@ -3,6 +3,13 @@
 
 <% if hsminweb.request.headers["User-Agent"]:match("Hammerspoon/[%d%.]+$") then %>
 
+<%
+    local invertLevel = settings.get("_documentationServer.invertDocs")
+    if type(invertLevel) == "nil" then invertLevel = (require"hs.host".interfaceStyle() == "Dark") end
+    if type(invertLevel) == "boolean" then invertLevel = invertLevel and 100 or 0 end
+    require("hs.doc").hsdocs._browser:darkMode(invertLevel > 50)
+%>
+
 <style type="text/css">
   div.searchbar {
     display: none;


### PR DESCRIPTION
This should cause the built in documentation browser to use the webview darkmode when its inverting content and address immediate triggering of console changes.

Did I miss anything?