### PR TITLE
AppleScript runstring can throw errors

### DIFF
--- a/extensions/_coresetup/init.lua
+++ b/extensions/_coresetup/init.lua
@@ -376,6 +376,22 @@ hs.fileDroppedToDockIconCallback = nil
       end
   end
 
+  hs.__appleScriptRunString = function(s)
+
+    --print("runstring")
+    local fn, err = load("return " .. s)
+    if not fn then fn, err = load(s) end
+    if not fn then return false, tostring(err) end
+
+    local str = ""
+    local results = pack(xpcall(fn,debug.traceback))
+    for i = 2,results.n do
+      if i > 2 then str = str .. "\t" end
+      str = str .. tostring(results[i])
+    end
+    return results[1], str
+  end
+
   -- load init.lua
 
   local function runstring(s)


### PR DESCRIPTION
Ok, took a slightly different approach and this version assumes `hs.__appleScriptRunString` is defined and returns two values.

Pros:
* can replace with own handler if you make sure to return two values
* if replaced with non-function, will throw AppleScript error

Cons:
* can replace with function that doesn't return two arguments and *may* cause hard to diagnose problems because of pop's pulling unknown contents off of stack.

Try with:

~~~
tell application "Hammerspoon"
	execute lua code "error([[I suck!]])"
end tell
~~~