### PR TITLE
Hs.midi

### DIFF
--- a/extensions/midi/init.lua
+++ b/extensions/midi/init.lua
@@ -19,4 +19,6 @@
 local USERDATA_TAG = "hs.midi"
 local module       = require(USERDATA_TAG..".internal")
 
+module.commandTypes = ls.makeConstantsTable(module.commandTypes)
+
 return module


### PR DESCRIPTION
Line 22 in `init.lua` -- makes table a constant table (user cannot easily muck it up by adding/removing elements; also adds __tostring so it can be viewed easily in console without requiring inspect

Line 73 -- make sure deviceCallbackRef starts out initialized with empty value
Lines 248-264, 1112, 1116 -- allow nil to stop watching for devices; don't recreate watcherDevice if it already exists; clear KVO watcher so can't be called after collection

Lines 586-706 -- fix some comment strings that might throw off some of the documentation generation tools used in various places; still wonder if some/all of the `lua_pushnumber` functions should actually be `lua_pushinteger`; will review MIDI spec later tonight and let you know my thoughts if you don't get to it and confirm/reject first.

Lines 1094-1095 -- clear callback function on collection

Lines 441,1096 -- not sure if a removal of the callback block is required; doesn't seem to crash without it even when replacing the callback multiple times, but what does the MIKMIDI library docs say?